### PR TITLE
Reintroduce regex to fix appcast_url parsing

### DIFF
--- a/cask-repair
+++ b/cask-repair
@@ -148,7 +148,7 @@ git checkout -b "${cask_branch}"
 cask_old_url=$(grep "url ['\"].*['\"]" "${cask_file}" | sed -E "s|.*url ['\"](.*)['\"].*|\1|")
 [[ "${cask_old_url}" =~ \#{version.*} ]] && cask_url_up_to_date='true'
 # get cask appcast url
-cask_appcast_url=$(grep "appcast '.*'" "${cask_file}" | sed -E "s|.*appcast '(.*)'|\1|")
+cask_appcast_url=$(grep "appcast '.*'" "${cask_file}" | sed -E "s|.*appcast '(.*)',|\1|")
 
 # show cask's current state
 divide


### PR DESCRIPTION
Without ,? the url incorporates the terminal comma should it exist.  Basically means the sha will be wrong, and in different ways depending on how the url is redirected.  Refs #4