### PR TITLE
Also check if the GITHUB_TOKEN environment variable is set

### DIFF
--- a/cask-repair
+++ b/cask-repair
@@ -10,7 +10,7 @@ show_appcast='false' # by default, do not open the cask's appcast
 warning_messages=()
 
 # check if 'hub' is installed and configured
-if [[ ! $(which 'hub') ]] || [[ ! $(grep 'oauth_token:' "${HOME}/.config/hub" 2>/dev/null) ]]; then
+if [[ ! $(which 'hub') ]] || [[ -z "${GITHUB_TOKEN}" && ! $(grep 'oauth_token:' "${HOME}/.config/hub" 2>/dev/null) ]]; then
   echo -e "$(tput setaf 1)
     This script requires 'hub' installed and configured.
     If you have [Homebrew](http://brew.sh), you can install it with 'brew install hub'.


### PR DESCRIPTION
If you configure you environment with a GITHUB_TOKEN environment variable, then hub will use it instead (it appears...since I'm able to run hub issues just fine - it doesn't even ask me to log in or anything)

However, the first check of cask-repair requires that a token be stored in ~/.config/hub. I would suggest that if the environment variable GITHUB_TOKEN is set, that the script also treats hub as "configured".

This PR fixes issue #21 