### PR TITLE
fastmerge, prfixmaster: Add issue number to commit message header

### DIFF
--- a/fastmerge
+++ b/fastmerge
@@ -100,6 +100,17 @@ apply_patch() {
 
   curl --location --silent "${patch_url}" | git am --quiet # get and apply patch
   [[ "$?" -ne 0 ]] && abort_patch 'revert' "There was an error applying the patch from ${url}. Reverted to last successful state." # if applying the patch was unsuccessful, warn and revert state
+
+  amend_message "${issue_number}"
+}
+
+amend_message() {
+  issue_number=$1
+  amended_message=$(git log --format=%B -n1 | sed "1 s/$/ (#${issue_number})/")
+
+  message "Amending commit message with issue number (#${issue_number})"
+
+  git commit --amend -F <(echo "${amended_message}")
 }
 
 push_and_close() {

--- a/prfixmaster
+++ b/prfixmaster
@@ -102,11 +102,22 @@ push_and_close() {
     git commit --amend -C HEAD
   fi
 
+  amend_message "${original_issue}"
+
   # push and close issue
   pull_remote
   git push "${remote}" master
 
   [[ "$?" -eq 0 ]] && ghi close --message "Thank you for the contribution. It needed some fixes, so they were made in ${last_commit_local}. Your contribution is still included (and still credited to you), with the appropriate modifications. Please feel free to ask about any of the changes." "${original_issue}"
+}
+
+amend_message() {
+  issue_number=$1
+  amended_message=$(git log --format=%B -n1 | sed "1 s/$/ (#${issue_number})/")
+
+  message "Amending commit message with issue number (#${issue_number})"
+
+  git commit --amend -F <(echo "${amended_message}")
 }
 
 if [[ "${1}" =~ https://github.com/* ]]; then


### PR DESCRIPTION
Emulate GitHub's behavior when squash-merging a PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vitorgalvao/tiny-scripts/25)
<!-- Reviewable:end -->
