### PR TITLE
Fix curl user-agent option

### DIFF
--- a/cask-repair
+++ b/cask-repair
@@ -2,7 +2,7 @@
 
 readonly program="$(basename "${0}")"
 readonly submit_pr_to='caskroom:master'
-readonly user_agent=(--user_agent 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.152 Safari/537.36')
+readonly user_agent=(--user-agent 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.152 Safari/537.36')
 remote_pull='upstream' # use 'upstream' as default remote to pull from
 remote_push='origin' # use 'origin' as default remote to push to
 show_home='false' # by default, do not open the cask's homepage


### PR DESCRIPTION
The recent change (https://github.com/vitorgalvao/tiny-scripts/commit/1614d268406ec4d5355cec7f870b5cf17e9c6771)  gives me following error message:
```
curl: option --user_agent: is unknown
curl: try 'curl --help' or 'curl --manual' for more information
```
The [manpage](https://curl.haxx.se/docs/manpage.html#-A) also states  this should be `--user-agent` instead of `--user_agent`.
(curl version 7.43.0)