### PR TITLE
cask-repair: use eval with EDITOR

### DIFF
--- a/cask-repair
+++ b/cask-repair
@@ -200,7 +200,7 @@ update_cask_shas() {
 
 # define function to open cask in appropriate editor
 edit_cask() {
-  [[ -n "${EDITOR}" ]] && "${EDITOR}" "${cask_file}" || open -W "${cask_file}"
+  [[ -n "${EDITOR}" ]] && eval "${EDITOR}" "${cask_file}" || open -W "${cask_file}"
 }
 
 # define function to add warnings to be shown on review


### PR DESCRIPTION
`EDITOR` can be set with arguments (e.g. `subl -n -w`), in which case directly applying it in quotes results in a "file not found" error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vitorgalvao/tiny-scripts/31)
<!-- Reviewable:end -->
