### PR TITLE
Include branch name when specifying upstream

### DIFF
--- a/cask-repair
+++ b/cask-repair
@@ -391,6 +391,6 @@ readonly hub_message="$(echo -e "${commit_message}\n\n### Changes to a cask\n###
 
 git commit "${cask_file}" --message "${commit_message}" --quiet
 git push "${remote_push}" "${cask_branch}" --quiet
-git branch --set-upstream-to "${remote_push}" --quiet # needed as workaround for hub to work with certain .gitconfig options to push default: https://github.com/github/hub/issues/789#issuecomment-72553866; after that issue is fixed, this line may likely be completely removed
+git branch --set-upstream-to "${remote_push}/${cask_branch}" --quiet # needed as workaround for hub to work with certain .gitconfig options to push default: https://github.com/github/hub/issues/789#issuecomment-72553866; after that issue is fixed, this line may likely be completely removed
 [[ -z "${issue_to_close}" ]] && pr_link=$(hub pull-request -b "${submit_pr_to}" -m "${hub_message}") || pr_link=$(hub pull-request -b "${submit_pr_to}" -m "$(echo -e "${hub_message}\n\n---\n\nCloses #${issue_to_close}.")")
 [[ -n "${pr_link}" ]] && finish success "${pr_link}" || finish abort 'There was an error submitting the pull request. Have you forked the repo and made sure the pull and push remotes exist?'


### PR DESCRIPTION
See https://github.com/vitorgalvao/tiny-scripts/issues/26#issuecomment-234400952

Avoid failures when setting upstream branch by using `remote/branch` instead of just `remote.` 