### PR TITLE
prfix*: fall back on 3-way merge if patch does not apply cleanly

### DIFF
--- a/prfixbranch
+++ b/prfixbranch
@@ -64,7 +64,7 @@ apply_patch() {
 
   branch_name="fix-${issue_number}"
   git checkout -b "${branch_name}"
-  curl --location --silent "${patch_url}" | git am # get and apply patch
+  curl --location --silent "${patch_url}" | git am --3way # get and apply patch
 
   git rev-parse HEAD > "${commit_hash_file}" # save hash from current commit
   echo "${issue_number}" > "${issue_number_file}" # save issue number

--- a/prfixmaster
+++ b/prfixmaster
@@ -85,7 +85,7 @@ apply_patch() {
   [[ "${current_branch}" != 'master' ]] && git checkout master
   pull_remote
 
-  curl --location --silent "${patch_url}" | git am # get and apply patch
+  curl --location --silent "${patch_url}" | git am --3way # get and apply patch
 
   echo "${issue_number}" > "${issue_number_file}" # save issue number
 


### PR DESCRIPTION
This way we can avoid manually editing `.git/rebase-apply/patch` and dealing with weird `git am` errors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vitorgalvao/tiny-scripts/34)
<!-- Reviewable:end -->
