### PR TITLE
fastmerge, prfix*: add tiny-scripts.remote config

### DIFF
--- a/fastmerge
+++ b/fastmerge
@@ -33,6 +33,12 @@ usage() {
   " | sed -E 's/^ {4}//'
 }
 
+# read remote from git config
+configured_remote="$(git config --get tiny-scripts.remote)"
+if [[ -n "${configured_remote}" ]]; then
+  remote="${configured_remote}"
+fi
+
 # available flags
 while [[ "${1}" ]]; do
   case "${1}" in

--- a/prfixbranch
+++ b/prfixbranch
@@ -22,6 +22,12 @@ usage() {
   " | sed -E 's/^ {4}//'
 }
 
+# read remote from git config
+configured_remote="$(git config --get tiny-scripts.remote)"
+if [[ -n "${configured_remote}" ]]; then
+  remote="${configured_remote}"
+fi
+
 # available flags
 while [[ "${1}" ]]; do
   case "${1}" in

--- a/prfixmaster
+++ b/prfixmaster
@@ -32,6 +32,12 @@ usage() {
   " | sed -E 's/^ {4}//'
 }
 
+# read remote from git config
+configured_remote="$(git config --get tiny-scripts.remote)"
+if [[ -n "${configured_remote}" ]]; then
+  remote="${configured_remote}"
+fi
+
 # available flags
 while [[ "${1}" ]]; do
   case "${1}" in


### PR DESCRIPTION
Instead of using the `--remote` flag every time if it's different from the default (`upstream`), just `git config tiny-scripts.remote {{remote}}`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vitorgalvao/tiny-scripts/35)
<!-- Reviewable:end -->
