### PR TITLE
prfix*: Exclude untracked files from uncommitted changes

### DIFF
--- a/prfixbranch
+++ b/prfixbranch
@@ -88,7 +88,7 @@ push_changes() {
   original_commit="$(cat ${commit_hash_file})"
   original_issue="#$(cat ${issue_number_file})"
   branch_name="$(git rev-parse --abbrev-ref HEAD)"
-  uncommitted_changes="$(git status --porcelain)"
+  uncommitted_changes="$(git status --porcelain --untracked-files=no)"
 
   # squash your fixes into the original patch, if there are uncommitted changes
   if [[ "${uncommitted_changes}" ]]; then

--- a/prfixmaster
+++ b/prfixmaster
@@ -111,7 +111,7 @@ rebase_squash() {
 
 push_and_close() {
   original_issue="$(cat ${issue_number_file})"
-  uncommitted_changes="$(git status --porcelain)"
+  uncommitted_changes="$(git status --porcelain --untracked-files=no)"
 
   # squash your fixes into the last commit, if there are uncommitted changes
   if [[ "${uncommitted_changes}" ]]; then


### PR DESCRIPTION
This recently bit me in https://github.com/caskroom/homebrew-cask/pull/23603.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vitorgalvao/tiny-scripts/36)
<!-- Reviewable:end -->
