### PR TITLE
stanza_to_modify now matches symbol-based values

### DIFF
--- a/cask-repair
+++ b/cask-repair
@@ -170,7 +170,7 @@ function modify_stanza {
   perl -0777 -i -e'
     $stanza_to_modify = shift(@ARGV);
     $new_stanza_value = shift(@ARGV);
-    print <> =~ s|\A.*^\s*\Q$stanza_to_modify\E\s\K[^\n]*|$new_stanza_value|smr;
+    print <> =~ s|\A.*^\s*\Q$stanza_to_modify\E\s\K[^\n]*['\''"]|$new_stanza_value|smr;
   ' "${stanza_to_modify}" "${new_stanza_value}" "${cask_file}"
 }
 

--- a/cask-repair
+++ b/cask-repair
@@ -170,7 +170,7 @@ function modify_stanza {
   perl -0777 -i -e'
     $stanza_to_modify = shift(@ARGV);
     $new_stanza_value = shift(@ARGV);
-    print <> =~ s|\A.*^\s*\Q$stanza_to_modify\E\s\K[^\n]*['\''"]|$new_stanza_value|smr;
+    print <> =~ s|\A.*^\s*\Q$stanza_to_modify\E\s\K[^\n]*['\''"]?|$new_stanza_value|smr;
   ' "${stanza_to_modify}" "${new_stanza_value}" "${cask_file}"
 }
 


### PR DESCRIPTION
It looks like cask-repair sets sha256 to :no_check when fetching a new version of a cask.  Once the new sha256 value is calculated, cask-repair tries to replace "sha256 :no_check" with the new value.

But it seems the regexp fed to perl expect the value to end with a ' or " but :no_check does not, so the sha256 stanza would stay as :no_check (at least on my machine).

Adding a ? at the end of the regexp seems to fix the issue for me and didn't seem to break anything else.