### PR TITLE
Add contributing and issue template

### DIFF
--- a/.github/Contributing.md
+++ b/.github/Contributing.md
@@ -1,0 +1,6 @@
+# Issues FAQ
+
+Issues are welcome. However please note of these instructions before filing new Issues for the following error messages
+
+- An error message stating `appcast is probably incorrect, as a non-200 (OK) HTTP response code was returned (301)`:
+  - Please do not file a new Issue to report this error message. It is either an issue from another command (ie, `hub`) or caused by certain git configs. Pull requests are welcome to squash this warning. Please see [#20](https://github.com/vitorgalvao/tiny-scripts/issues/20) for more information.

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,3 @@
+Please read [Contributing.md](./Contributing.md) before filing a new Issue. This will help you determine whether you can avoid filing a new Issue in certain cases.
+
+===== DELETE THIS LINE AND ABOVE =====


### PR DESCRIPTION
This adds a contributing guide and an issue template to this project. My main intent here is to help avoid unnecessary duplicate issues be filed, such as the problem reported in Issue #20. I can see future use cases where both the contributing guide and issue template can be expanded to serve additional present or future use cases.

I hope this helps.