### PR TITLE
cask-repair: use hub default remote & protocol with custom branch prefix

### DIFF
--- a/cask-repair
+++ b/cask-repair
@@ -10,7 +10,7 @@ readonly user_agent=(--user-agent 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10) ht
 readonly hub_config="${HOME}/.config/hub"
 readonly github_username="$(awk '/user:/{print $(NF)}' "${hub_config}" 2>/dev/null | head -1)"
 readonly cask_repair_remote_name="${github_username}"
-readonly cask_repair_branch_prefix="cask_repair_update"
+readonly cask_repair_branch_prefix='cask_repair_update'
 readonly submission_error_log="$(mktemp)"
 
 show_home='false' # By default, do not open the cask's homepage

--- a/cask-repair
+++ b/cask-repair
@@ -3,13 +3,14 @@
 readonly program="$(basename "${0}")"
 export readonly MACOS_VERSION='10.12' # Latest macOS version, so commands like `fetch` are not dependent on the contributor’s OS
 readonly submit_pr_to='caskroom:master'
-readonly cask_repair_remote_name='cask-repair'
 readonly caskroom_origin_remote_regex='(https://|git@)github.com[/:]caskroom/'
 readonly caskroom_taps=(homebrew-cask homebrew-versions homebrew-fonts homebrew-eid homebrew-drivers)
 readonly caskroom_taps_dir="$(brew --repository)/Library/Taps/caskroom"
 readonly user_agent=(--user-agent 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10) http://caskroom.io')
 readonly hub_config="${HOME}/.config/hub"
 readonly github_username="$(awk '/user:/{print $(NF)}' "${hub_config}" 2>/dev/null | head -1)"
+readonly cask_repair_remote_name="${github_username}"
+readonly cask_repair_branch_prefix="cask_repair_update"
 readonly submission_error_log="$(mktemp)"
 
 show_home='false' # By default, do not open the cask's homepage
@@ -75,7 +76,7 @@ function usage {
       -b, --blind-submit                     Submit cask without asking for confirmation, if there are no errors.
       -f, --fail-on-error                    If there are any errors with the submission, abort.
       -i, --install-cask                     Installs your updated cask after submission.
-      -d, --delete-branches                  Deletes all local and remote branches named like ${cask_repair_remote_name}_update-<word>.
+      -d, --delete-branches                  Deletes all local and remote branches named like ${cask_repair_branch_prefix}-<word>.
       -h, --help                             Show this help.
   " | sed -E 's/^ {4}//'
 }
@@ -121,9 +122,7 @@ function ensure_cask_repair_remote {
   if ! git remote | grep --silent "${cask_repair_remote_name}"; then
     warning_message "A \`${cask_repair_remote_name}\` remote does not exist. Creating it now…"
 
-    git config --local hub.protocol https
-    hub fork --no-remote
-    git remote add "${cask_repair_remote_name}" "https://github.com/${github_username}/$(current_tap)"
+    hub fork
   fi
 }
 
@@ -249,12 +248,12 @@ function delete_created_branches {
 
     if git remote | grep --silent "${cask_repair_remote_name}"; then # Proceed only if the correct remote exists
       # Delete local branches
-      local_branches=$(git branch --all | grep --extended-regexp "^ *${cask_repair_remote_name}_update-.+$" | perl -pe 's|^ *||;s|\n| |')
+      local_branches=$(git branch --all | grep --extended-regexp "^ *${cask_repair_branch_prefix}-.+$" | perl -pe 's|^ *||;s|\n| |')
       [[ -n "${local_branches}" ]] && git branch -D ${local_branches}
 
       # Delete remote branches
       git fetch --prune "${cask_repair_remote_name}"
-      remote_branches=$(git branch --all | grep --extended-regexp "remotes/${cask_repair_remote_name}/${cask_repair_remote_name}_update-.+$" | perl -pe 's|.*/||;s|\n| |')
+      remote_branches=$(git branch --all | grep --extended-regexp "remotes/${cask_repair_remote_name}/${cask_repair_branch_prefix}-.+$" | perl -pe 's|.*/||;s|\n| |')
       [[ -n "${remote_branches}" ]] && git push "${cask_repair_remote_name}" --delete ${remote_branches}
     fi
 
@@ -399,7 +398,7 @@ for cask in "${@}"; do
   # Clean the cask's name, and check if it is valid
   cask_name="${cask%.rb}" # Remove '.rb' extension, if present
   cask_file="./${cask_name}.rb"
-  cask_branch="${cask_repair_remote_name}_update-${cask_name}"
+  cask_branch="${cask_repair_branch_prefix}-${cask_name}"
 
   cd_to_cask_tap "${cask_name}.rb"
   require_correct_origin


### PR DESCRIPTION
This pull request addresses issues raised in #85 and #86 while taking into consideration challenges presented in #61 and #57. The goal is to support both git and https protocols and use by default what the user has configured with hub.

With this change cask-repair avoids setting user configurable preferences either in the local repository with `git config --local hub.protocol https` or globally with `git config --global hub.protocol https` and does not enforce a custom remote name for the user's fork.

A simple `hub fork` is now used to create both the fork and the remote. Checks are still performed to ensure the remote is present based on the known default remote name. Branch names are no longer based on the remote name and instead use a cask_repair_branch_prefix followed by a hyphen and the cask name. This allows cask-repair to use the standard hub remote while naming branches exactly as they were before. This minimizes the impact of the change in behavior and migration to the default remote and allows `--delete-branches` functionality to continue working. If `--delete-branches` is run after these updates, it will work even to delete branches which were created before the cask-repair script was updated.

Both #61 and #57 were review and neither raises any concers with these modifications. #61 was primarily an inquiry about git protocol support which we are now adding and #57 was dealing with a user who had modified the origin to use the git protocol. These changes deal only with the remote for the user's fork and do not make any modifications to the checks ensuring the proper origin. Both homebrew-core and homebrew-cask assume https origins and the current checks ensure the origin is configured per the standard distribution. Any discussion around changing the origin should probably fall within the scope of those respective projects.

All functionality, including `--delete-branches` has been tested and appears to be working with both git and https remotes with cask-repair now respecting the hub.protocol setting as configured by the user either locally for the cask tap or globally.