### PR TITLE
cask-repair: update PR template

### DIFF
--- a/cask-repair
+++ b/cask-repair
@@ -535,7 +535,7 @@ for cask in "${@}"; do
 
   # Commit, push, submit pull request, clean
   commit_message="Update ${cask_name} to ${cask_version}"
-  hub_message="$(echo -e "${commit_message}\n\nAfter making all changes to the cask:\n\n- [x] \`brew cask audit --download {{cask_file}}\` is error-free.\n- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.\n- [x] The commit message includes the cask’s name and version.\n\nAdditionally, if **updating a cask**:\n\n- [ ] **I verified this change is legitimate**<sup>[how do I do that?][version-checksum]</sup>. I did so because \`sha256\` was altered, but \`version\` was not. I’m providing confirmation below, [as instructed by the guide][version-checksum].")"
+  hub_message="$(echo -e "${commit_message}\n\nAfter making all changes to the cask:\n\n- [x] \`brew cask audit --download {{cask_file}}\` is error-free.\n- [x] \`brew cask style --fix {{cask_file}}\` left no offenses.\n- [x] The commit message includes the cask’s name and version.\n\nAdditionally, if **updating a cask**:\n\n- [ ] **I verified this change is legitimate**<sup>[how do I do that?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)</sup>. I did so because \`sha256\` was altered, but \`version\` was not. I’m providing confirmation below, [as instructed by the guide](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256).")"
   submit_pr_from="${github_username}:${cask_branch}"
 
   git commit "${cask_file}" --message "${commit_message}" --quiet


### PR DESCRIPTION
Changes `[version-checksum]` to a URL.