### PR TITLE
Stay in cask repo when repairing

### DIFF
--- a/cask-repair
+++ b/cask-repair
@@ -66,7 +66,7 @@ function require_hub {
   fi
 
   if [[ -z "${github_username}" ]] || [[ -z "${GITHUB_TOKEN}" && ! $(grep 'oauth_token:' "${hub_config}" 2>/dev/null) ]]; then
-    failure_message '`hub` is not configured.\nTo do it, run `cd $(brew --repository) && hub issue`. Your Github password will be required, but is never stored.'
+    failure_message '`hub` is not configured.\nTo do it, run `(cd $(brew --repository) && hub issue)`. Your Github password will be required, but is never stored.'
   fi
 }
 


### PR DESCRIPTION
For a first-time user, this instruction leaves them in
`/usr/local/Homebrew` unexpectedly. Everything works fine... it's just
weird.

The only important think about being in `brew --repository` is that it
is known to be a gitlab repo, so it's a good, confident bet, fine to
keep using.

But by running this in a subshell, it will keep the user in their
existing directory