### PR TITLE
cask-repair: remove lock on script exit failures

### DIFF
--- a/cask-repair
+++ b/cask-repair
@@ -32,12 +32,14 @@ function color_message {
 
   if [[ -z "${color_index}" ]]; then
     echo "${FUNCNAME[0]}: '${color}' is not a valid color."
+    lock 'remove'
     exit 1
   fi
 }
 
 function failure_message {
   color_message 'red' "${1}" >&2
+  lock 'remove'
   exit 1
 }
 


### PR DESCRIPTION
In situations where the script fails, the lock does not get removed (i.e. hub not being configured on a fresh install).