### PR TITLE
cask-repair: audit options match CI checks

### DIFF
--- a/cask-repair
+++ b/cask-repair
@@ -539,7 +539,7 @@ for cask in "${@}"; do
     style_result="${?}"
     [[ "${style_result}" -ne 0 ]] && add_warning error "${style_message}"
 
-    audit_message=$(brew cask audit "${cask_file}" 2>/dev/null)
+    audit_message=$(brew cask audit --download --appcast --token-conflicts "${cask_file}" 2>/dev/null)
     audit_result="${?}"
     [[ "${audit_result}" -ne 0 ]] && add_warning error "${audit_message}"
 


### PR DESCRIPTION
I noticed that audit checks in `cask-repair` would pass but would fail when run on Travis. When looking at the [Homebrew CI file](https://github.com/Homebrew/homebrew-cask/blob/master/cmd/brewcask-ci.rb#L42-L44), I noticed that Travis will run the command line equivalent to `brew cask audit --download --appcast --token-conflicts [token]`. This script currently runs the basic `brew cask audit [token]`.

It would be nice to have both this script and Travis run the same `brew cask audit` commands.