### PR TITLE
cask-repair: Ensure we branch off of master

### DIFF
--- a/cask-repair
+++ b/cask-repair
@@ -461,7 +461,7 @@ for cask in "${@}"; do
 
   has_language_stanza? "${cask_file}" && abort "${cask_name} has a language stanza. It cannot be updated via this script. Try update_multilangual_casks: https://github.com/Homebrew/homebrew-cask/blob/master/developer/bin/update_multilangual_casks"
 
-  git rev-parse --verify "${cask_branch}" &>/dev/null && git checkout "${cask_branch}" --quiet || git checkout -b "${cask_branch}" --quiet # Create branch or checkout if it already exists
+  git rev-parse --verify "${cask_branch}" &>/dev/null && git checkout "${cask_branch}" master --quiet || git checkout -b "${cask_branch}" master --quiet # Create branch or checkout if it already exists
 
   # Open home and appcast
   [[ "${show_home}" == 'true' ]] && brew cask home "${cask_file}"


### PR DESCRIPTION
When I use cask-repair and need to amend the PR with additional changes, I often checkout the automatically created branch locally but forget to checkout master afterwards. Subsequently repairing a cask then creates a new branch off of the branch I used to make the changes, instead of the master branch. In such cases, the PR then contains the previous cask repair as well.

This PR fixes this issue by ensuring we always branch off of the master branch.

Potential extensions:
- Remember which branch we come from, and checkout that branch again after the repair.
*I'm not sure whether this is a good idea, since then I might get stuck on a custom branch without knowing and not receive updates for multiple days.*
- Automatically stash uncommitted changes before checking out the new branch, and reapply the changes after navigating back to the branch.
*Likely barely useful*