### PR TITLE
cask-repair: fix download file path is not retrieved correctly

### DIFF
--- a/cask-repair
+++ b/cask-repair
@@ -228,7 +228,7 @@ function sha_change {
     clean
     abort "There was an error fetching ${cask_file}. Please check your connection and try again."
   fi
-  downloaded_file=$(brew cask fetch "${cask_file}" 2>/dev/null | tail -1 | sed 's/==> Success! Downloaded to -> //')
+  downloaded_file=$(HOMEBREW_NO_COLOR=1 brew cask fetch "${cask_file}" 2>/dev/null | tail -1 | sed 's/==> Success! Downloaded to -> //')
   package_sha=$(shasum --algorithm 256 "${downloaded_file}" | awk '{ print $1 }')
 
   modify_stanza 'sha256' "\"${package_sha}\"" "${cask_file}"


### PR DESCRIPTION
Fixes https://github.com/vitorgalvao/tiny-scripts/issues/196

`brew cask fetch` returns color output which causes `sed` not to strip the redundant text correctly in certain environment (specifically, in my case, GitHub Actions). This fixes the bug by simply setting `brew cask fetch` to return the plain text output (Ref: https://github.com/Homebrew/brew/pull/3090/files). 