### PR TITLE
cask-repair fix package_sha for brew fetch output

### DIFF
--- a/cask-repair
+++ b/cask-repair
@@ -215,7 +215,7 @@ function has_appcast {
 }
 
 function sha_change {
-  local cask_sha_deliberatedly_unchecked downloaded_file package_sha cask_file given_sha
+  local cask_sha_deliberatedly_unchecked package_sha cask_file given_sha
 
   cask_file="${1}"
   given_sha="${2}"
@@ -236,8 +236,7 @@ function sha_change {
     clean
     abort "There was an error fetching ${cask_file}. Please check your connection and try again."
   fi
-  downloaded_file=$(HOMEBREW_NO_COLOR=1 brew fetch --cask "${cask_file}" 2>/dev/null | tail -1 | sed 's/==> Success! Downloaded to -> //')
-  package_sha=$(shasum --algorithm 256 "${downloaded_file}" | awk '{ print $1 }')
+  package_sha=$(HOMEBREW_NO_COLOR=1 brew fetch --cask "${cask_file}" 2>/dev/null | tail -1 | sed 's/SHA256: //')
 
   modify_stanza 'sha256' "\"${package_sha}\"" "${cask_file}"
 }

--- a/cask-repair
+++ b/cask-repair
@@ -236,7 +236,7 @@ function sha_change {
     clean
     abort "There was an error fetching ${cask_file}. Please check your connection and try again."
   fi
-  package_sha=$(HOMEBREW_NO_COLOR=1 brew fetch --cask "${cask_file}" 2>/dev/null | tail -1 | sed 's/SHA256: //')
+  package_sha="$(HOMEBREW_NO_COLOR=1 brew fetch --cask "${cask_file}" 2>/dev/null | tail -1 | sed 's/SHA256: //')"
 
   modify_stanza 'sha256' "\"${package_sha}\"" "${cask_file}"
 }


### PR DESCRIPTION
When switched from `brew cask fetch` to `brew fetch --cask` in #201  output is changed and is now printing sha256 as last line. This fixes sha256 calculation.

Previously this following error;
```
• audit for loopback: failed
 - sha256 string must be of 64 hexadecimal characters
```

Because of `brew cask fetch` command outputs;
```
ykursadkaya@YKKs-MacBook-Air: ~% brew cask fetch cyberduck
Warning: Calling brew cask fetch is deprecated! Use brew fetch [--cask] instead.

==> Downloading external files for Cask cyberduck
==> Downloading https://update.cyberduck.io/Cyberduck-7.7.2.33862.zip
Already downloaded: /Users/ykursadkaya/Library/Caches/Homebrew/downloads/f09cc72c465cbf599635002ca568ce633f1c01733f0926de7122b6735931c5a0--Cyberduck-7.7.2.33862.zip
==> Success! Downloaded to -> /Users/ykursadkaya/Library/Caches/Homebrew/downloads/f09cc72c465
```

and `brew fetch` command outputs;
```
ykursadkaya@YKKs-MacBook-Air: ~% brew fetch cyberduck
==> Downloading https://update.cyberduck.io/Cyberduck-7.7.2.33862.zip
Already downloaded: /Users/ykursadkaya/Library/Caches/Homebrew/downloads/f09cc72c465cbf599635002ca568ce633f1c01733f0926de7122b6735931c5a0--Cyberduck-7.7.2.33862.zip
SHA256: 3becbea9d43261e8b8ddc139164c5744bb5535602bf994d400aedf8767fc1f44
```